### PR TITLE
(fix): configur auth for `clientSecret` and `apiKey`

### DIFF
--- a/apis/AdminAPIsOverrides.yml
+++ b/apis/AdminAPIsOverrides.yml
@@ -1,0 +1,12 @@
+components:
+  securitySchemes:
+    apiKey:
+      x-fern-header:
+        name: apiKey
+        env: CROSSMINT_API_KEY
+        type: optional<string>
+x-fern-global-headers:
+  - header: Authorization
+    name: clientSecret
+    type: optional<string>
+    env: CROSSMINT_CLIENT_SECRET

--- a/apis/HeadlessAPIsOverrides.yml
+++ b/apis/HeadlessAPIsOverrides.yml
@@ -1,0 +1,4 @@
+paths: 
+  /2022-06-09/orders/{orderId}:
+    patch:
+      security: null

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "crossmint",
-  "version": "0.36.0"
+  "version": "0.37.0"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -1,6 +1,8 @@
 api: 
-  - ../apis/AdminAPIs.yaml
-  - ../apis/HeadlessAPIs.yaml
+  - path: ../apis/AdminAPIs.yaml
+    overrides: ../apis/AdminAPIsOverrides.yml
+  - path: ../apis/HeadlessAPIs.yaml
+    overrides: ../apis/HeadlessAPIsOverrides.yml
   - ../apis/MintingAPIs.yaml
   - ../apis/PaymentsAPIs.yaml
   - ../apis/VerifiableCredentialsAPIs.yaml
@@ -9,7 +11,7 @@ groups:
   ts-sdk:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.36.4
+        version: 0.36.6
         output:
           location: npm
           package-name: "crossmint"


### PR DESCRIPTION
This PR makes it so that a user can optionally provide `clientSecret` and `apiKey`